### PR TITLE
Update SendNscaFactory.php

### DIFF
--- a/src/SendNscaFactory.php
+++ b/src/SendNscaFactory.php
@@ -49,7 +49,7 @@ class SendNscaFactory implements Ciphers {
 	 * @return EncryptorInterface
 	 * @throws \Exception
 	 */
-    protected function getEncryptor(int $cipher, string $password): EncryptorInterface {
+    protected function getEncryptor(int $cipher, string $password): ?EncryptorInterface {
 		try {
 			if ($cipher === Ciphers::ENCRYPT_NONE) {
 				return null;


### PR DESCRIPTION
With PHP >= 7.1, seems that null is rejected as return value, when return type is declared.
This causes an issue with ENCRYPT_NONE, as SendNscaFactory::getEncryptor expects EncryptorInterface, but null is returned when cipher is ENCRYPT_NONE.